### PR TITLE
fix: use new installer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,15 @@ RUN apt-get update && \
     apt-get install --no-install-recommends -y \ 
     curl file python3 locales libquadmath0 ca-certificates && \
     locale-gen en_US.UTF-8 en_GB.UTF-8 && \
-    curl -sSO https://fsl.fmrib.ox.ac.uk/fsldownloads/fslinstaller.py && \
+    curl -sSO https://fsl.fmrib.ox.ac.uk/fsldownloads/fslconda/releases/fslinstaller.py && \
     if [ ! -z ${CI_REGISTRY} ]; then sed -i -E -e 's,(^\s*prog.update|^\s*progress)\(,\1\,\(,' fslinstaller.py; fi && \
-    python3 fslinstaller.py -d /usr/local/fsl -V ${APP_VERSION} && \
+    python3 fslinstaller.py \
+    -d /usr/local/fsl \
+    -V ${APP_VERSION} \
+    --no_self_update \
+    --skip_registration \
+    --throttle_downloads \
+    && \
     rm fslinstaller.py && \
     rm -rf /usr/local/fsl/src && \
     apt-get remove -y --purge curl file && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,16 +19,16 @@ WORKDIR /apps/${APP_NAME}
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install --no-install-recommends -y \ 
-    curl file python3 locales libquadmath0 ca-certificates && \
+        curl file python3 locales libquadmath0 ca-certificates && \
     locale-gen en_US.UTF-8 en_GB.UTF-8 && \
     curl -sSO https://fsl.fmrib.ox.ac.uk/fsldownloads/fslconda/releases/fslinstaller.py && \
     if [ ! -z ${CI_REGISTRY} ]; then sed -i -E -e 's,(^\s*prog.update|^\s*progress)\(,\1\,\(,' fslinstaller.py; fi && \
     python3 fslinstaller.py \
-    -d /usr/local/fsl \
-    -V ${APP_VERSION} \
-    --no_self_update \
-    --skip_registration \
-    --throttle_downloads \
+        -d /usr/local/fsl \
+        -V ${APP_VERSION} \
+        --no_self_update \
+        --skip_registration \
+        --throttle_downloads \
     && \
     rm fslinstaller.py && \
     rm -rf /usr/local/fsl/src && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ ARG DOCKERFS_VERSION
 FROM ${CI_REGISTRY_IMAGE}/${DOCKERFS_TYPE}:${DOCKERFS_VERSION}${TAG}
 LABEL maintainer="nathalie.casati@chuv.ch"
 
-ARG DEBIAN_FRONTEND=noninteractive
 ARG CARD
 ARG CI_REGISTRY
 ARG APP_NAME
@@ -16,19 +15,18 @@ LABEL app_tag=$TAG
 
 WORKDIR /apps/${APP_NAME}
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install --no-install-recommends -y \ 
-        curl file python3 locales libquadmath0 ca-certificates && \
+        curl file python3 locales libquadmath0 ca-certificates libgomp1 && \
     locale-gen en_US.UTF-8 en_GB.UTF-8 && \
     curl -sSO https://fsl.fmrib.ox.ac.uk/fsldownloads/fslconda/releases/fslinstaller.py && \
-    if [ ! -z ${CI_REGISTRY} ]; then sed -i -E -e 's,(^\s*prog.update|^\s*progress)\(,\1\,\(,' fslinstaller.py; fi && \
-    python3 fslinstaller.py \
+    python3 ./fslinstaller.py \
         -d /usr/local/fsl \
         -V ${APP_VERSION} \
         --no_self_update \
         --skip_registration \
-        --throttle_downloads \
     && \
     rm fslinstaller.py && \
     rm -rf /usr/local/fsl/src && \


### PR DESCRIPTION
Cf. https://git.fmrib.ox.ac.uk/fsl/conda/installer

The current one fails consistently this way, see: https://gitlab.hbp.link/hip/app-in-browser/-/jobs/3057

```
FSL installer version: 3.2.0
Press CTRL+C at any time to cancel installation
Running the installer script as root user is discouraged! You should run this script as a regular user - you will be asked for your administrator password if required.
Installation log file: /tmp/fslinstaller_51abbvrb.log
New installer file does not match expected checksum! Skipping update.
FSL 6.0.7.9 selected for installation
Downloading FSL environment specification from https://fsl.fmrib.ox.ac.uk/fsldownloads/fslconda/releases/fsl-6.0.7.9_linux-64.yml...
Installing FSL in /usr/local/fsl
Downloading miniconda from https://repo.anaconda.com/miniconda/Miniconda3-py311_24.3.0-0-Linux-x86_64.sh...
Installing miniconda at /usr/local/fsl...
ERROR occurred during installation!
    int() argument must be a string, a bytes-like object or a real number, not 'dict'
Removing failed installation directory /usr/local/fsl
FSL installation failed!
```

The old one is not properly handling the case where the `version` is set to 4.

https://git.fmrib.ox.ac.uk/fsl/conda/installer/-/blob/main/fsl/installer/fslinstaller.py?ref_type=heads#L2216-2228

More docs: https://fsl.fmrib.ox.ac.uk/fsl/docs/#/install/container